### PR TITLE
Minor Debian/Ubuntu tweak

### DIFF
--- a/scripts/travis-tool.sh
+++ b/scripts/travis-tool.sh
@@ -32,7 +32,7 @@ BootstrapLinux() {
   sudo apt-get update -qq
 
   # Install R.
-  sudo apt-get install r-base r-base-dev
+  sudo apt-get install r-base-dev
 }
 
 BootstrapMac() {


### PR DESCRIPTION
One just needs r-base-dev, it pulls in r-base-core.  And one doesn't need the doc packages pulled in by the (meta-)package r-base.
