### PR TITLE
add travis-tool.sh to package's .Rbuildignore during bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This package has a simple shell script for use in running R package builds on
 [travis](http://travis-ci.org/), along with a sample `.travis.yml` file. One
 should be able to set up travis for their own project by:
 * Copying `sample.travis.yml` to `.travis.yml` in your project.
-* Adding `.travis.yml` and `travis-tool.sh` to your `.Rbuildignore`.
+* Adding `.travis.yml` to your `.Rbuildignore`.
 * Modifying `.travis.yml` to list any packages that must be installed from
   github (instead of CRAN).
 * [Turn on travis](https://travis-ci.org/profile) for your project.

--- a/fakepackage/.Rbuildignore
+++ b/fakepackage/.Rbuildignore
@@ -1,1 +1,0 @@
-^travis-tool\.sh$

--- a/scripts/travis-tool.sh
+++ b/scripts/travis-tool.sh
@@ -16,6 +16,8 @@ Bootstrap() {
         echo "Unknown OS: ${OS}"
         exit 1
     fi
+
+    echo '^travis-tool\.sh$' >> .Rbuildignore
 }
 
 BootstrapLinux() {


### PR DESCRIPTION
The name of the travis-tool.sh script should be opaque to the user,
and the script is not even part of the package's repository.
