### PR TITLE
Undoing earlier overzealous pull request

### DIFF
--- a/scripts/travis-tool.sh
+++ b/scripts/travis-tool.sh
@@ -48,8 +48,8 @@ BootstrapMac() {
 
 DevtoolsInstall() {
     # Install devtools.
-    Rscript -e 'install.packages(\"devtools\", repos=\"'"${CRAN}"'\")'
-    Rscript -e 'library(devtools); library(methods); install_github(\"devtools\")'
+    Rscript -e 'install.packages("devtools", repos="'"${CRAN}"'")'
+    Rscript -e 'library(devtools); library(methods); install_github("devtools")'
     # Mark installation
     HAVE_DEVTOOLS="yes"
 }
@@ -76,7 +76,7 @@ RInstall() {
     fi
 
     echo "RInstall: Installing ${pkg}"
-    Rscript -e 'install.packages(commandArgs(TRUE), repos=\"'"${CRAN}"'\")' $*
+    Rscript -e 'install.packages(commandArgs(TRUE), repos="'"${CRAN}"'")' $*
 }
 
 GithubPackage() {
@@ -102,7 +102,7 @@ GithubPackage() {
 
     echo "Installing package: ${PACKAGE_NAME}"
     # Install the package.
-    Rscript -e 'library(devtools); library(methods); options(repos=c(CRAN=\"'"${CRAN}"'\")); install_github(\"'"${PACKAGE_NAME}"'\"'"${ARGS}"')'
+    Rscript -e 'library(devtools); library(methods); options(repos=c(CRAN="'"${CRAN}"'")); install_github("'"${PACKAGE_NAME}"'"'"${ARGS}"')'
 }
 
 InstallDeps() {
@@ -110,7 +110,7 @@ InstallDeps() {
         DevtoolsInstall
     fi
 
-    Rscript -e 'library(devtools); library(methods); options(repos=c(CRAN=\"'"${CRAN}"'\")); devtools:::install_deps(dependencies = TRUE)'
+    Rscript -e 'library(devtools); library(methods); options(repos=c(CRAN="'"${CRAN}"'")); devtools:::install_deps(dependencies = TRUE)'
 }
 
 RunTests() {


### PR DESCRIPTION
With these change, I can again build the embedded package, and can do so without touching other files.

devtools still does get installed multiple times even from CRAN -- I don't really care as I don't use it. 

I may take a break here.  The project does what I need it to do for my work on github.
