### PR TITLE
Add `travis-tool` to `.Rbuildignore` automatically and idempotently.

### DIFF
--- a/scripts/travis-tool.sh
+++ b/scripts/travis-tool.sh
@@ -18,7 +18,7 @@ Bootstrap() {
         exit 1
     fi
 
-    test -e .Rbuildignore && grep -q 'travis\-tool' .Rbuildignore
+    test -e .Rbuildignore && grep -q 'travis-tool' .Rbuildignore
     if [[ $? -ne 0 ]]; then
         echo '^travis-tool\.sh$' >>.Rbuildignore
     fi


### PR DESCRIPTION
This is a little on the fancy side, but will be important if we ever want to
push the built packages anywhere (since they'll accidentally pick up
`travis-tool.sh` otherwise).
