### PR TITLE
dump results of tests

### DIFF
--- a/scripts/travis-tool.sh
+++ b/scripts/travis-tool.sh
@@ -116,7 +116,7 @@ RunTests() {
     FILE=$(ls -1 *.tar.gz)
     R CMD check "${FILE}" --no-manual --as-cran
     RES=$?
-    ls -1 ../*.Rcheck/tests/*Rout* | xargs cat
+    cat *.Rcheck/tests/*.Rout*
     exit $RES
 }
 


### PR DESCRIPTION
Because `R CMD check` just gives the last few lines of test runs, it is not that useful. 

This small patch prints the content of the `*.Rout` and `*.Rout.fail` files into the travis log. 

The idea is for some other tool to grab the log and do something useful with it. I'm working on that with the [travis](https://github.com/romainfrancois/travis) package. 
