### PR TITLE
add BOOTSTRAP_LATEX environment option to bootstrap command to install TeXlive on Ubuntu and OS X

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,11 @@ language: c
 # language: objective-c
 
 env:
-  - R_BUILD_ARGS=" "
+  global:
+    - R_BUILD_ARGS=" "
+  matrix:
+    - BOOTSTRAP_LATEX=""
+    - BOOTSTRAP_LATEX="1"
 script: ./travis-tool.sh run_tests
 notifications:
   email:
@@ -17,6 +21,7 @@ before_install:
   - cp scripts/travis-tool.sh fakepackage
   - cd fakepackage
   - ./travis-tool.sh bootstrap
+  - source /etc/profile # Need to reload PATH on OS X
 before_script:
   - ./travis-tool.sh dump_sysinfo
 after_success:
@@ -47,3 +52,6 @@ install:
   - ./travis-tool.sh r_binary_install RUnit survey
   - Rscript -e 'library(RUnit); library(survey)'
   - ./travis-tool.sh dump_sysinfo | grep -q 'R version '
+  # Test --latex option: pdflatex, kpsewhich
+  - if test "${BOOTSTRAP_OPTS/--latex/}" != "${BOOTSTRAP_OPTS}"; then test -n "$(which kpsewhich)"; fi
+  - if test "${BOOTSTRAP_OPTS/--latex/}" != "${BOOTSTRAP_OPTS}"; then test -n "$(which pdflatex)"; fi

--- a/sample.travis.yml
+++ b/sample.travis.yml
@@ -10,6 +10,7 @@ before_install:
   - curl -OL http://raw.github.com/craigcitro/r-travis/master/scripts/travis-tool.sh
   - chmod 755 ./travis-tool.sh
   - ./travis-tool.sh bootstrap
+  - source /etc/profile # Need to reload PATH on OS X
 install:
   - ./travis-tool.sh install_deps
   - ./travis-tool.sh github_package assertthat
@@ -38,7 +39,9 @@ branches:
 # here are the defaults:
 # env:
 #   global:
+#     - CRAN="http://cran.rstudio.com"
 #     - R_BUILD_ARGS="--no-build-vignettes"
 #     - R_CHECK_ARGS="--no-manual --as-cran"
+#     - BOOTSTRAP_LATEX=""
 # See the travis docs for more information:
 #   http://about.travis-ci.org/docs/user/build-configuration/#The-Build-Matrix

--- a/scripts/travis-tool.sh
+++ b/scripts/travis-tool.sh
@@ -46,16 +46,43 @@ BootstrapLinux() {
     # This should really be via 'staff adduser travis staff'
     # but that may affect only the next shell
     sudo chmod 2777 /usr/local/lib/R /usr/local/lib/R/site-library
+
+    # Process options
+    BootstrapLinuxOptions
+}
+
+BootstrapLinuxOptions() {
+    if [ -n "$BOOTSTRAP_LATEX" ]; then
+        sudo apt-get install --no-install-recommends \
+            texlive-base texlive-latex-base texlive-generic-recommended \
+            texlive-fonts-recommended texlive-fonts-extra \
+            texlive-extra-utils texlive-latex-recommended texlive-latex-extra \
+            texinfo lmodern
+    fi
 }
 
 BootstrapMac() {
-    # TODO(craigcitro): Figure out TeX in OSX+travis.
-
     # Install from latest CRAN binary build for OS X
     wget ${CRAN}/bin/macosx/R-latest.pkg  -O /tmp/R-latest.pkg
 
     echo "Installing OS X binary package for R"
     sudo installer -pkg "/tmp/R-latest.pkg" -target /
+    rm "/tmp/R-latest.pkg"
+
+    # Process options
+    BootstrapMacOptions
+}
+
+BootstrapMacOptions() {
+    if [ -n "$BOOTSTRAP_LATEX" ]; then
+        # TODO: Install MacTeX.pkg once there's enough disk space
+        MACTEX=mactex-basic.pkg
+        wget http://ctan.math.utah.edu/ctan/tex-archive/systems/mac/mactex/$MACTEX -O "/tmp/$MACTEX"
+
+        echo "Installing OS X binary package for MacTeX"
+        sudo installer -pkg "/tmp/$MACTEX" -target /
+        rm "/tmp/$MACTEX"
+    fi
 }
 
 EnsureDevtools() {


### PR DESCRIPTION
fixes #52
