### PR TITLE
install binary R packages with just one apt-get install call -- again

### DIFF
--- a/scripts/travis-tool.sh
+++ b/scripts/travis-tool.sh
@@ -107,11 +107,14 @@ RBinaryInstall() {
         exit 1
     fi
 
-    for r_package in $*; do
-        echo "Installing *binary* R package: ${r_package}"
+    r_packages=$*
+    r_debs=$(for r_package in ${r_packages}; do
         r_deb="r-cran-$(echo "${r_package}" | tr '[:upper:]' '[:lower:]')"
-        sudo apt-get install "${r_deb}"
-    done
+        echo -n "${r_deb} "
+    done)
+
+    echo "Installing *binary* R packages: ${r_packages}"
+    sudo apt-get install ${r_debs}
 }
 
 GithubPackage() {


### PR DESCRIPTION
- otherwise the logs just look horrible: e.g.,
  https://travis-ci.org/yihui/tikzDevice/builds/13447667, lines 365-700
- runtime penalty is substantial, too

Compare with run using this branch: https://travis-ci.org/yihui/tikzDevice/builds/13448326. It's about 30-60 secs faster, and the logs are much nicer.
