### PR TITLE
Expose EnsureDevtools again through old command devtools_install

### DIFF
--- a/scripts/travis-tool.sh
+++ b/scripts/travis-tool.sh
@@ -190,8 +190,7 @@ case $COMMAND in
         Bootstrap
         ;;
     "devtools_install")
-        # TODO(craigcitro): Delete this function, since we don't need it.
-        echo '***** devtools_install is deprecated and will soon disappear. *****'
+        EnsureDevtools
         ;;
     "aptget_install")
         AptGetInstall "$*"


### PR DESCRIPTION
Reason: Running extensive integration tests (such as in tikzDevice) that are
not part of R CMD check but require installation of the package

Installation can be done easily by `devtools:::install('.')`
