### PR TITLE
allow specifying R version through environment variable R_VERSION

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ language: c
 
 env:
   matrix:
-    - BOOTSTRAP_LATEX=" "
+    - R_VERSION="2.15" R_CHECK_ARGS="--no-build-vignettes --no-manual" BOOTSTRAP_LATEX=" "
     - R_BUILD_ARGS=" " R_CHECK_ARGS="--as-cran" BOOTSTRAP_LATEX="1"
 script: ./travis-tool.sh run_tests
 notifications:


### PR DESCRIPTION
- determine Ubuntu versions for r-base-dev, r-base-core and r-recommended
- don't install R docs
- don't install r-recommends when version has been specified (doesn't work);
  hence, don't check as CRAN for R 2.15 in test setup

Addresses parts of #9.
