### PR TITLE
r-binary-install uses r-install as fallback if not running Linux or FORCE_SOURCE_INSTALL is set

### DIFF
--- a/scripts/travis-tool.sh
+++ b/scripts/travis-tool.sh
@@ -141,7 +141,7 @@ RBinaryInstall() {
         exit 1
     fi
 
-    if [[ "Linux" != "${OS}" -o -n "${FORCE_SOURCE_INSTALL}" ]]; then
+    if [[ "Linux" != "${OS}" ]] || [[ -n "${FORCE_SOURCE_INSTALL}" ]]; then
         echo "Fallback: Installing from source"
         RInstall "$@"
         return


### PR DESCRIPTION
- avoids clutter in the `.travis.yml` when testing for Linux and OS X
- allows the user to choose not to install from c2d4u
