### PR TITLE
Update sample configuration to dump logs on failure

### DIFF
--- a/sample.travis.yml
+++ b/sample.travis.yml
@@ -14,7 +14,7 @@ install:
   - ./travis-tool.sh install_deps
 script: ./travis-tool.sh run_tests
 
-on_failure:
+after_failure:
   - ./travis-tool.sh dump_logs
 
 notifications:


### PR DESCRIPTION
Trivial change here - The key `on_failure` should be `after_failure` or the logs are not dumped on failure.
