### PR TITLE
Devtools tweaks

### DIFF
--- a/scripts/travis-tool.sh
+++ b/scripts/travis-tool.sh
@@ -185,7 +185,7 @@ InstallGithub() {
 
 InstallDeps() {
     EnsureDevtools
-    Rscript -e 'library(devtools); library(methods); options(repos=c(CRAN="'"${CRAN}"'")); devtools:::install_deps(dependencies = TRUE)'
+    Rscript -e 'library(devtools); library(methods); options(repos=c(CRAN="'"${CRAN}"'")); install_deps(dependencies = TRUE)'
 }
 
 DumpSysinfo() {


### PR DESCRIPTION
Couple of tiny devtools tweaks: we can save some time by not building vignettes of github dependences (since no one will ever look at them) and `install_deps()` is now exported.
