### PR TITLE
Call R CMD INSTALL --build on Windows

### DIFF
--- a/scripts/travis-tool.sh
+++ b/scripts/travis-tool.sh
@@ -252,7 +252,7 @@ RunTests() {
     fi
 
     # Create binary package (currently Windows only)
-    if [[ "${OS}" == "MINGW*" ]]; then
+    if [[ "${OS:0:5}" == "MINGW" ]]; then
         echo "Creating binary package"
         R CMD INSTALL --build "${FILE}"
     fi


### PR DESCRIPTION
This calls `R CMD INSTALL --build` on Windows when running the `run_tests` verb, to generate a binary `.zip` package.
