### PR TITLE
Get time info for R CMD check

### DIFF
--- a/scripts/travis-tool.sh
+++ b/scripts/travis-tool.sh
@@ -255,7 +255,7 @@ RunTests() {
     
     if [[ ${R_CHECK_TIME} == "FALSE" ]]; then
         _R_CHECK_CRAN_INCOMING_=${_R_CHECK_CRAN_INCOMING_} R CMD check "${FILE}" ${R_CHECK_ARGS}
-    else
+    elif [[ ${R_CHECK_TIME} == "TRUE" ]]; then
         if [[ "${OS}" == "Linux" || "${OS}" == "Darwin" ]]; then
             time _R_CHECK_CRAN_INCOMING_=${_R_CHECK_CRAN_INCOMING_} R CMD check "${FILE}" ${R_CHECK_ARGS}
         elif [[ "${OS:0:5}" == "MINGW" ]]; then
@@ -266,6 +266,8 @@ RunTests() {
             echo "Unknown OS (${OS}) and cannot check time"
             _R_CHECK_CRAN_INCOMING_=${_R_CHECK_CRAN_INCOMING_} R CMD check "${FILE}" ${R_CHECK_ARGS}
         fi
+    else
+        echo "R_CHECK_TIME should be set to TRUE or FALSE."
     fi
 
     # Check reverse dependencies


### PR DESCRIPTION
This PR addresses issue https://github.com/craigcitro/r-travis/issues/129 by running `time` under Linux or Mac (Darwin) OS. The option to get the time information is set by the environment variable `R_CHECK_TIME` which should be set to either `TRUE` or `FALSE`. I set the default to `FALSE` so current r-travis users will not see it's behavior altered. I'm leaving it to @craigcitro to decide what's best.
## Windows OS

For Windows, I used https://github.com/krlmlr/r-travis/commit/bfe01cc6cbae8d4c18e455bafb64f2352994606d to detect the OS. Then, from http://stackoverflow.com/questions/673523/how-to-measure-execution-time-of-command-in-windows-command-line it seems to me that you need some type of external tool to help you measure the time a command takes. So... I believe that the basic option is to simply print the date and time before and after running `R CMD check`. In Windows' command prompt, you do this by using:

```
echo "%DATE% %TIME%"
```

as used [here](https://github.com/lcolladotor/r-travis/commit/5b8738346c0311497e243ffff8393fc6537b1e6f#diff-af8c4a369d33252caf6ed0def84d631cR262). 

Now, it is not clear to me how travis-tool.sh can run on Windows machines. For example, `uname -s` doesn't work on the Windows command prompt. So well, if for some reason `time` can be used, this PR can be simplified.
## Working example

An example of this change working can be seen here: [Travis report](https://travis-ci.org/lcolladotor/derfinderHelper/builds/35178234), [.travis.yml](https://github.com/lcolladotor/derfinderHelper/commit/16a91a8c8bccf7a1c6312f098ae72ada07ed3340).
## Misc

I saw that you have `_R_CHECK_CRAN_INCOMING_` but couldn't tell what it does. I guess the name implies that at some point there'll be a feature that uses it.

If you like this small change, I'll document it on the wiki.
