### PR TITLE
Update the default pandoc version to 1.13.1.

### DIFF
--- a/scripts/travis-tool.sh
+++ b/scripts/travis-tool.sh
@@ -11,7 +11,7 @@ BIOC=${BIOC:-"http://bioconductor.org/biocLite.R"}
 BIOC_USE_DEVEL=${BIOC_USE_DEVEL:-"TRUE"}
 OS=$(uname -s)
 
-PANDOC_VERSION='1.12.4.2'
+PANDOC_VERSION='1.13.1'
 PANDOC_DIR="${HOME}/opt/pandoc"
 PANDOC_URL="https://s3.amazonaws.com/rstudio-buildtools/pandoc-${PANDOC_VERSION}.zip"
 


### PR DESCRIPTION
This picks up a change to the binaries we use so that they always include
templates, which was causing issues for some users.

Fixes #145.

PTAL @cboettig -- can you confirm that this fixes the issue you were seeing? (you should be able to just use `/pandoc_update/`instead of `/master/` in your `.travis.yml` to test.)