### PR TITLE
Add a deprecation notice for r-travis.

### DIFF
--- a/scripts/travis-tool.sh
+++ b/scripts/travis-tool.sh
@@ -311,6 +311,11 @@ Retry() {
 }
 
 COMMAND=$1
+echo "\033[0;31m
+r-travis is DEPRECATED!
+Please see https://docs.travis-ci.com/user/languages/r/ for info, or
+https://github.com/craigcitro/r-travis/wiki/Porting-to-native-R-support-in-Travis
+for information on porting to native R support in Travis.\033[0m"
 echo "Running command: ${COMMAND}"
 shift
 case $COMMAND in


### PR DESCRIPTION
This addresses one part of #179.

However, looking at the logs, it's a little ... easy to miss? Short of adding `sleep 5` calls, any thoughts on ways to make this a bit more obvious?

PTAL @hadley @jimhester 
